### PR TITLE
Mount local FHIR cache

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,10 +44,6 @@ RUN apk update && apk add --no-cache jq findutils curl ca-certificates
 RUN mkdir -p /home/vscode/.fhir/validators/
 RUN wget -q https://github.com/hapifhir/org.hl7.fhir.core/releases/download/$JAVA_VALIDATOR_VERSION/validator_cli.jar -O /home/vscode/.fhir/validators/validator_cli.jar
 
-# Set ownership
-RUN mkdir -p /home/vscode/.fhir/packages && \
-    chown -R vscode:vscode /home/vscode/.fhir/packages
-
 RUN mkdir -p /home/vscode/.fhir/settings/
 COPY codfsh-config.yaml /home/vscode/.fhir/settings/codfsh-config.yaml
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,10 @@
 				"codfsh.HapiValidator.Settings.SettingsFile": "/home/vscode/.fhir/settings/codfsh-config.yaml"
 			}
 		}
-	}
+	},
+	"mounts": [
+		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.fhir/packages,target=/home/vscode/.fhir/packages,type=bind"
+	]
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/Resources/fsh-generated/resources/Patient-PatientinMusterfrau.json
+++ b/Resources/fsh-generated/resources/Patient-PatientinMusterfrau.json
@@ -11,8 +11,12 @@
       "type": {
         "coding": [
           {
-            "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
-            "code": "GKV"
+            "code": "MR",
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203"
+          },
+          {
+            "code": "GKV",
+            "system": "http://fhir.de/CodeSystem/identifier-type-de-basis"
           }
         ]
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-ExamplePatient.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ExamplePatient.json
@@ -1,16 +1,6 @@
 {
   "resourceType": "StructureDefinition",
   "id": "ExamplePatient",
-  "extension": [
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-category",
-      "valueString": "Base.Individuals"
-    },
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category",
-      "valueCode": "patient"
-    }
-  ],
   "url": "https://gematik.de/fhir/isik/v2/Basismodul/StructureDefinition/ExamplePatient",
   "name": "ExamplePatient",
   "status": "active",
@@ -305,14 +295,12 @@
         "id": "Patient.name:Name.family.extension:nachname",
         "path": "Patient.name.family.extension",
         "sliceName": "nachname",
-        "max": "1",
         "mustSupport": true
       },
       {
         "id": "Patient.name:Name.family.extension:vorsatzwort",
         "path": "Patient.name.family.extension",
         "sliceName": "vorsatzwort",
-        "max": "1",
         "mustSupport": true
       },
       {
@@ -379,14 +367,12 @@
         "id": "Patient.name:Geburtsname.family.extension:nachname",
         "path": "Patient.name.family.extension",
         "sliceName": "nachname",
-        "max": "1",
         "mustSupport": true
       },
       {
         "id": "Patient.name:Geburtsname.family.extension:vorsatzwort",
         "path": "Patient.name.family.extension",
         "sliceName": "vorsatzwort",
-        "max": "1",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ExampleValueSet.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ExampleValueSet.json
@@ -1,16 +1,6 @@
 {
   "resourceType": "StructureDefinition",
   "id": "ExampleValueSet",
-  "extension": [
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-category",
-      "valueString": "Foundation.Terminology"
-    },
-    {
-      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category",
-      "valueCode": "anonymous"
-    }
-  ],
   "url": "https://gematik.de/fhir/isik/v2/Basismodul/StructureDefinition/ExampleValueSet",
   "name": "ExampleValueSet",
   "status": "active",


### PR DESCRIPTION
# Contributor Pull Request
Mount local FHIR cache instead of each devcontainer having its own FHIR cache.

## Description
Mounts the user specific FHIR cache from `~/.fhir/packages` into the dev container at `/home/vscode/.fhir/packages`. The home directory on the host system is determined using OS environment variables for Windows and *nix and MacOS. By mounting only the `.fhir/package` sub-directory instead of the whole `.fhir` directory, container specific FHIR configuration like for _codfsh_ will still be separated for each container.

## Motivation and Context
By not having each devcontainer have its own FHIR cache, the required storage space is reduced, and packages don't need to be re-downloaded and inflated again and again.

## How has this been tested?
Tested on my local Linux machine and was also used in previous projects on a Windows machine.

## Snippets or Screenshots (if necessary):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this IG / specification.
- [ ] My change requires a change to the documentation or narrative (intend) of the IG.
- [ ] I have already updated the documentation / narrative (intend) accordingly.