### PR TITLE
Update Firely Terminal Pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       # Java and .NET are already installed on ubuntu-latest
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       # Java and .NET are already installed on ubuntu-latest
         
       - name: Firely.Terminal (GitHub Actions)
-        uses: FirelyTeam/firely-terminal-pipeline@v0.4.0
+        uses: FirelyTeam/firely-terminal-pipeline@v0.4.1
         with:
           PATH_TO_CONFORMANCE_RESOURCES: Resources/fsh-generated/resources/
           #PATH_TO_EXAMPLES: Examples


### PR DESCRIPTION
Siehe https://github.com/FirelyTeam/firely-terminal-pipeline/releases/tag/v0.4.1
Die Default SUSHI-Version wurde in der Pipeline auch angepasst (v3.8.0), hier würde die würde sie überschrieben mit 3.5.0.