### PR TITLE
added link check action

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,39 @@
+name: Check Links
+# This workflow checks for broken links in the repository.
+
+on:
+  pull_request:
+    # Trigger the workflow on any pull request targeting any branch.
+    branches:
+      - '**'
+
+jobs:
+  link_checker:
+    # Define a job named "link_checker" that runs the link-checking process.
+    runs-on: ubuntu-latest
+    # Specify the virtual machine environment to run the job (latest Ubuntu).
+
+    steps:
+      - name: Checkout repository
+        # Step 1: Checkout the repository code into the workflow environment.
+        uses: actions/checkout@v3
+        # Use the official GitHub checkout action (version 3).
+
+      - name: Run Link Checker
+        # Step 2: Run the Lychee link-checking tool.
+        uses: lycheeverse/lychee-action@v2
+        # Use the Lychee GitHub Action (version 2) for link checking.
+
+        with:  
+          fail: true
+          # Configure the workflow to fail if broken links are found.
+          # Run the link checker on the current directory and all its contents.
+          # Exclude links matching the pattern for Jira links (e.g., HL7 Jira).
+          # Exclude all links in the "ImplementationGuide/style" directory.
+          # Exclude all links in the "Material" directory.
+          args: >
+            .
+            --exclude '^https://jira\.hl7\.org'
+            --exclude-path ImplementationGuide/style
+            --exclude-path Material
+            


### PR DESCRIPTION
# Contributor Pull Request
Added a link check action 

## Description
The link checker will run on every pull request. It will fail, if a link does not resolve. 

## Motivation and Context
We found various links that do not resolve. For this reason, an automated check should take place. There is an option to configure this process. By default, the "Material" and "ImplementationGuide/style" folders are excluded from the check. Additionally, all links to jira.hl7.org are ignored.

## How has this been tested?
The action has been tested on the Dokumentenaustausch IG, version 3



